### PR TITLE
[Imp] comment NOGROUP var

### DIFF
--- a/ttdnsd/ttdnsd.h
+++ b/ttdnsd/ttdnsd.h
@@ -60,7 +60,8 @@ const int MAX_TCP_WRITE_TIME = 10;
 const int RECV_BUF_SIZE = 1502;
 
 const int NOBODY = 65534;
-const int NOGROUP = 65534;
+//Expected unqualified-id after XCode9 beta, it seems "NOGROUP" is been registered, and "NOGROUP" is never been used.
+//const int NOGROUP = 65534;
 const int DEFAULT_DNS_PORT = 53;
 const char DEFAULT_DNS_IP[]= "8.8.8.8";
 const int DEFAULT_BIND_PORT = 53;


### PR DESCRIPTION
build error
Expected unqualified-id after XCode9 beta,
it seems "NOGROUP" is been registered, and "NOGROUP" is never been used.